### PR TITLE
Implement scanner.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/doeg/golox
 
 go 1.19
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/golox/loxerror/loxerror.go
+++ b/golox/loxerror/loxerror.go
@@ -1,0 +1,17 @@
+package loxerror
+
+import "fmt"
+
+type LoxError struct {
+	Line    int
+	Message string
+}
+
+var (
+	ErrUnexpectedCharacter = "unexpected character %x"
+	ErrUnterminatedString  = "unterminated string"
+)
+
+func (e *LoxError) Error() string {
+	return fmt.Sprintf("[line %d] Error: %s\n", e.Line, e.Message)
+}

--- a/golox/scanner/scanner.go
+++ b/golox/scanner/scanner.go
@@ -1,0 +1,255 @@
+package scanner
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/doeg/golox/golox/loxerror"
+	"github.com/doeg/golox/golox/token"
+)
+
+type Scanner struct {
+	source []byte
+	tokens []token.Token
+
+	// start points to the first character in the lexeme being scanned
+	start int
+
+	// current points at the character currently being considered
+	current int
+
+	// line tracks which source line current is on so we can produce
+	// tokens that know their location
+	line int
+
+	// errors accumulates syntax errors as the scanner progresses
+	// so as many errors as possible can be collected in a single scan pass
+	errors []loxerror.LoxError
+}
+
+func New(source []byte) *Scanner {
+	return &Scanner{
+		errors: make([]loxerror.LoxError, 0),
+		source: source,
+		tokens: make([]token.Token, 0),
+	}
+}
+
+func (scanner *Scanner) ScanTokens() ([]token.Token, []loxerror.LoxError) {
+	for !scanner.isAtEnd() {
+		// We are at the beginning of the next lexeme
+		scanner.start = scanner.current
+		scanner.scanToken()
+	}
+
+	return scanner.tokens, scanner.errors
+}
+
+// addOperatorToken adds an operator token (i.e., a token without a literal value)
+// to the list of tokens.
+func (scanner *Scanner) addOperatorToken(tokenType token.TokenType) {
+	scanner.addToken(tokenType, nil)
+}
+
+func (scanner *Scanner) addToken(tokenType token.TokenType, literal interface{}) {
+	text := scanner.source[scanner.start:scanner.current]
+	scanner.tokens = append(scanner.tokens, token.Token{
+		Lexeme:  string(text),
+		Line:    scanner.line,
+		Literal: literal,
+		Type:    tokenType,
+	})
+}
+
+// advance consumes the next ASCII character in the source file and returns it.
+func (scanner *Scanner) advance() byte {
+	b := scanner.source[scanner.current]
+	scanner.current++
+	return b
+}
+
+// advanceUntilNewline advances the scanner until a newline character is encountered,
+// or the scanner reaches the end of 'source'. Note that the newline character
+// is not consumed, nor is 'scanner.line' advanced.
+func (scanner *Scanner) advanceUntilNewline() {
+	for scanner.peek() != '\n' && !scanner.isAtEnd() {
+		scanner.advance()
+	}
+}
+
+// isAtEnd returns true when all of the characters in 'source' have been consumed.
+func (scanner *Scanner) isAtEnd() bool {
+	return scanner.current >= len(scanner.source)
+}
+
+// match returns true and consumes the current character if it matches 'expected'.
+// In other words, it is like a conditional 'advance()'.
+func (scanner *Scanner) match(expected byte) bool {
+	if !scanner.isAtEnd() && scanner.peek() == expected {
+		scanner.current++
+		return true
+	}
+
+	return false
+}
+
+// peek is a one-character lookahead, returning the current character without consuming it.
+func (scanner *Scanner) peek() byte {
+	if scanner.isAtEnd() {
+		return '\x00'
+	}
+	return scanner.source[scanner.current]
+}
+
+func (scanner *Scanner) peekNext() byte {
+	if scanner.current+1 >= len(scanner.source) {
+		return '\x00'
+	}
+
+	return scanner.source[scanner.current+1]
+}
+
+func (scanner *Scanner) recordError(message string) {
+	scanner.errors = append(scanner.errors, loxerror.LoxError{
+		Line:    scanner.line,
+		Message: message,
+	})
+}
+
+func (scanner *Scanner) scanIdentifier() {
+	for isAlphaNumeric(scanner.peek()) {
+		scanner.advance()
+	}
+
+	text := scanner.source[scanner.start:scanner.current]
+	tokenType, ok := token.Keywords[string(text)]
+	if ok {
+		scanner.addOperatorToken(tokenType)
+	} else {
+		scanner.addOperatorToken(token.IDENTIFIER)
+	}
+}
+
+func (scanner *Scanner) scanNumber() {
+	for isDigit(scanner.peek()) {
+		scanner.advance()
+	}
+
+	if scanner.peek() == '.' && isDigit(scanner.peekNext()) {
+		// Consume the decimal
+		scanner.advance()
+
+		for isDigit(scanner.peek()) {
+			scanner.advance()
+		}
+	}
+
+	str := scanner.source[scanner.start:scanner.current]
+	dbl, _ := strconv.ParseFloat(string(str), 64)
+	scanner.addToken(token.NUMBER, dbl)
+
+}
+
+func (scanner *Scanner) scanString() {
+	for scanner.peek() != '"' && !scanner.isAtEnd() {
+		if scanner.peek() == '\n' {
+			scanner.line++
+		}
+		scanner.advance()
+	}
+
+	if scanner.isAtEnd() {
+		scanner.recordError(loxerror.ErrUnterminatedString)
+		return
+	}
+
+	// Consume the closing '"' character
+	scanner.advance()
+
+	// Trim the surrounding quotes from the string literal
+	val := scanner.source[scanner.start+1 : scanner.current-1]
+	scanner.addToken(token.STRING, string(val))
+}
+
+func (scanner *Scanner) scanToken() {
+	b := scanner.advance()
+	switch b {
+	case '(':
+		scanner.addOperatorToken(token.LEFT_PAREN)
+	case ')':
+		scanner.addOperatorToken(token.RIGHT_PAREN)
+	case '{':
+		scanner.addOperatorToken(token.LEFT_BRACE)
+	case '}':
+		scanner.addOperatorToken(token.RIGHT_BRACE)
+	case ',':
+		scanner.addOperatorToken(token.COMMA)
+	case '.':
+		scanner.addOperatorToken(token.DOT)
+	case '-':
+		scanner.addOperatorToken(token.MINUS)
+	case '+':
+		scanner.addOperatorToken(token.PLUS)
+	case ';':
+		scanner.addOperatorToken(token.SEMICOLON)
+	case '/':
+		if scanner.match('/') {
+			scanner.advanceUntilNewline()
+		} else {
+			scanner.addOperatorToken(token.SLASH)
+		}
+	case '*':
+		scanner.addOperatorToken(token.STAR)
+	case '!':
+		if scanner.match('=') {
+			scanner.addOperatorToken(token.BANG_EQUAL)
+		} else {
+			scanner.addOperatorToken(token.BANG)
+		}
+	case '=':
+		if scanner.match('=') {
+			scanner.addOperatorToken(token.EQUAL_EQUAL)
+		} else {
+			scanner.addOperatorToken(token.EQUAL)
+		}
+	case '>':
+		if scanner.match('=') {
+			scanner.addOperatorToken(token.GREATER_EQUAL)
+		} else {
+			scanner.addOperatorToken(token.GREATER)
+		}
+	case '<':
+		if scanner.match('=') {
+			scanner.addOperatorToken(token.LESS_EQUAL)
+		} else {
+			scanner.addOperatorToken(token.LESS)
+		}
+	case '"':
+		scanner.scanString()
+	case ' ', '\r', '\t':
+		// Continue, ignoring whitespace
+	case '\n':
+		scanner.line++
+	default:
+		switch {
+		case isDigit(b):
+			scanner.scanNumber()
+		case isAlpha(b):
+			scanner.scanIdentifier()
+		default:
+			scanner.recordError(fmt.Sprintf(loxerror.ErrUnexpectedCharacter, b))
+		}
+	}
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_'
+}
+
+func isAlphaNumeric(b byte) bool {
+	return isAlpha(b) || isDigit(b)
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/golox/scanner/scanner.go
+++ b/golox/scanner/scanner.go
@@ -42,6 +42,8 @@ func (scanner *Scanner) ScanTokens() ([]token.Token, []loxerror.LoxError) {
 		scanner.scanToken()
 	}
 
+	scanner.tokens = append(scanner.tokens, token.Token{Line: scanner.line, Type: token.EOF})
+
 	return scanner.tokens, scanner.errors
 }
 

--- a/golox/scanner/scanner_test.go
+++ b/golox/scanner/scanner_test.go
@@ -21,22 +21,26 @@ func TestScanTokens(t *testing.T) {
 			expected: []token.Token{
 				{Line: 0, Lexeme: "(", Type: token.LEFT_PAREN},
 				{Line: 0, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 0, Type: token.EOF},
 			},
 		},
+
 		{
 			input: "\"string literal\"",
 			expected: []token.Token{
 				{Line: 0, Lexeme: "\"string literal\"", Literal: "string literal", Type: token.STRING},
+				{Line: 0, Type: token.EOF},
 			},
 		},
 		{
 			input: "\"multiline\nstring\"",
 			expected: []token.Token{
 				{Line: 1, Lexeme: "\"multiline\nstring\"", Literal: "multiline\nstring", Type: token.STRING},
+				{Line: 1, Type: token.EOF},
 			},
 		},
 		{
-			testName: "unterminated string",
+			testName: "error: unterminated string",
 			input:    "\"",
 			expectedErrors: []loxerror.LoxError{
 				{Line: 0, Message: loxerror.ErrUnterminatedString},
@@ -46,12 +50,14 @@ func TestScanTokens(t *testing.T) {
 			input: "1234",
 			expected: []token.Token{
 				{Line: 0, Lexeme: "1234", Literal: float64(1234), Type: token.NUMBER},
+				{Line: 0, Type: token.EOF},
 			},
 		},
 		{
 			input: "12.34",
 			expected: []token.Token{
 				{Line: 0, Lexeme: "12.34", Literal: 12.34, Type: token.NUMBER},
+				{Line: 0, Type: token.EOF},
 			},
 		},
 		{
@@ -60,16 +66,18 @@ func TestScanTokens(t *testing.T) {
 				{Line: 0, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
 				{Line: 0, Lexeme: "!=", Type: token.BANG_EQUAL},
 				{Line: 0, Lexeme: "2", Literal: float64(2), Type: token.NUMBER},
+				{Line: 0, Type: token.EOF},
 			},
 		},
 		{
 			input: "// this is a comment\n!=",
 			expected: []token.Token{
 				{Line: 1, Lexeme: "!=", Type: token.BANG_EQUAL},
+				{Line: 1, Type: token.EOF},
 			},
 		},
 		{
-			testName: "invalid character",
+			testName: "error: invalid character",
 			input:    "@",
 			expected: nil,
 			expectedErrors: []loxerror.LoxError{
@@ -77,7 +85,7 @@ func TestScanTokens(t *testing.T) {
 			},
 		},
 		{
-			testName: "invalid characters (multiline)",
+			testName: "error: invalid characters (multiline)",
 			input:    "@\n$",
 			expected: nil,
 			expectedErrors: []loxerror.LoxError{
@@ -93,6 +101,55 @@ func TestScanTokens(t *testing.T) {
 				{Line: 0, Lexeme: "=", Type: token.EQUAL},
 				{Line: 0, Lexeme: "\"lox\"", Literal: "lox", Type: token.STRING},
 				{Line: 0, Lexeme: ";", Type: token.SEMICOLON},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "var average = (min + max)/2;",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "var", Type: token.VAR},
+				{Line: 0, Lexeme: "average", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "=", Type: token.EQUAL},
+				{Line: 0, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 0, Lexeme: "min", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "+", Type: token.PLUS},
+				{Line: 0, Lexeme: "max", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 0, Lexeme: "/", Type: token.SLASH},
+				{Line: 0, Lexeme: "2", Literal: float64(2), Type: token.NUMBER},
+				{Line: 0, Lexeme: ";", Type: token.SEMICOLON},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: `
+				var a = 1;
+				while (a <= 10) {
+					print a;
+				}
+			`,
+			expected: []token.Token{
+				{Line: 1, Lexeme: "var", Type: token.VAR},
+				{Line: 1, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "=", Type: token.EQUAL},
+				{Line: 1, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
+				{Line: 1, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 2, Lexeme: "while", Type: token.WHILE},
+				{Line: 2, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 2, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: "<=", Type: token.LESS_EQUAL},
+				{Line: 2, Lexeme: "10", Literal: float64(10), Type: token.NUMBER},
+				{Line: 2, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 2, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 3, Lexeme: "print", Type: token.PRINT},
+				{Line: 3, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 3, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 4, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 5, Type: token.EOF},
 			},
 		},
 	}

--- a/golox/scanner/scanner_test.go
+++ b/golox/scanner/scanner_test.go
@@ -152,6 +152,179 @@ func TestScanTokens(t *testing.T) {
 				{Line: 5, Type: token.EOF},
 			},
 		},
+		{
+			input: `
+				if (condition) {
+					print "yes";
+				} else {
+					print "no";
+				}
+			`,
+			expected: []token.Token{
+				{Line: 1, Lexeme: "if", Type: token.IF},
+				{Line: 1, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 1, Lexeme: "condition", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 1, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 2, Lexeme: "print", Type: token.PRINT},
+				{Line: 2, Lexeme: "\"yes\"", Literal: "yes", Type: token.STRING},
+				{Line: 2, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 3, Lexeme: "}", Type: token.RIGHT_BRACE},
+				{Line: 3, Lexeme: "else", Type: token.ELSE},
+				{Line: 3, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 4, Lexeme: "print", Type: token.PRINT},
+				{Line: 4, Lexeme: "\"no\"", Literal: "no", Type: token.STRING},
+				{Line: 4, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 5, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 6, Type: token.EOF},
+			},
+		},
+		{
+			input: `
+				for (var a = 1; a < 10; a = a + 1) {
+					print a;
+				}
+			`,
+			expected: []token.Token{
+				{Line: 1, Lexeme: "for", Type: token.FOR},
+				{Line: 1, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 1, Lexeme: "var", Type: token.VAR},
+				{Line: 1, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "=", Type: token.EQUAL},
+				{Line: 1, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
+				{Line: 1, Lexeme: ";", Type: token.SEMICOLON},
+				{Line: 1, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "<", Type: token.LESS},
+				{Line: 1, Lexeme: "10", Literal: float64(10), Type: token.NUMBER},
+				{Line: 1, Lexeme: ";", Type: token.SEMICOLON},
+				{Line: 1, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "=", Type: token.EQUAL},
+				{Line: 1, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "+", Type: token.PLUS},
+				{Line: 1, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
+				{Line: 1, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 1, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 2, Lexeme: "print", Type: token.PRINT},
+				{Line: 2, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 3, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 4, Type: token.EOF},
+			},
+		},
+		{
+			input: "makeBreakfast(bagel, creamCheese, lox);",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "makeBreakfast", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 0, Lexeme: "bagel", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: ",", Type: token.COMMA},
+				{Line: 0, Lexeme: "creamCheese", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: ",", Type: token.COMMA},
+				{Line: 0, Lexeme: "lox", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 0, Lexeme: ";", Type: token.SEMICOLON},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: `
+				fun outerFunction() {
+					fun innerFunction(str) {
+						print str;
+					}
+
+					innerFunction("hello");
+				}
+			`,
+			expected: []token.Token{
+				{Line: 1, Lexeme: "fun", Type: token.FUN},
+				{Line: 1, Lexeme: "outerFunction", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 1, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 1, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 2, Lexeme: "fun", Type: token.FUN},
+				{Line: 2, Lexeme: "innerFunction", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 2, Lexeme: "str", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 2, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 3, Lexeme: "print", Type: token.PRINT},
+				{Line: 3, Lexeme: "str", Type: token.IDENTIFIER},
+				{Line: 3, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 4, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 6, Lexeme: "innerFunction", Type: token.IDENTIFIER},
+				{Line: 6, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 6, Lexeme: "\"hello\"", Literal: "hello", Type: token.STRING},
+				{Line: 6, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 6, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 7, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 8, Type: token.EOF},
+			},
+		},
+		{
+			input: `
+				class Brunch < Breakfast {
+					init(meat, bread, drink) {
+						super.init(meat, bread);
+						this.drink = drink;
+					}
+				}
+			`,
+			expected: []token.Token{
+				{Line: 1, Lexeme: "class", Type: token.CLASS},
+				{Line: 1, Lexeme: "Brunch", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "<", Type: token.LESS},
+				{Line: 1, Lexeme: "Breakfast", Type: token.IDENTIFIER},
+				{Line: 1, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 2, Lexeme: "init", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 2, Lexeme: "meat", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: ",", Type: token.COMMA},
+				{Line: 2, Lexeme: "bread", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: ",", Type: token.COMMA},
+				{Line: 2, Lexeme: "drink", Type: token.IDENTIFIER},
+				{Line: 2, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 2, Lexeme: "{", Type: token.LEFT_BRACE},
+
+				{Line: 3, Lexeme: "super", Type: token.SUPER},
+				{Line: 3, Lexeme: ".", Type: token.DOT},
+				{Line: 3, Lexeme: "init", Type: token.IDENTIFIER},
+				{Line: 3, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 3, Lexeme: "meat", Type: token.IDENTIFIER},
+				{Line: 3, Lexeme: ",", Type: token.COMMA},
+				{Line: 3, Lexeme: "bread", Type: token.IDENTIFIER},
+				{Line: 3, Lexeme: ")", Type: token.RIGHT_PAREN},
+				{Line: 3, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 4, Lexeme: "this", Type: token.THIS},
+				{Line: 4, Lexeme: ".", Type: token.DOT},
+				{Line: 4, Lexeme: "drink", Type: token.IDENTIFIER},
+				{Line: 4, Lexeme: "=", Type: token.EQUAL},
+				{Line: 4, Lexeme: "drink", Type: token.IDENTIFIER},
+				{Line: 4, Lexeme: ";", Type: token.SEMICOLON},
+
+				{Line: 5, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 6, Lexeme: "}", Type: token.RIGHT_BRACE},
+
+				{Line: 7, Type: token.EOF},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/golox/scanner/scanner_test.go
+++ b/golox/scanner/scanner_test.go
@@ -40,13 +40,6 @@ func TestScanTokens(t *testing.T) {
 			},
 		},
 		{
-			testName: "error: unterminated string",
-			input:    "\"",
-			expectedErrors: []loxerror.LoxError{
-				{Line: 0, Message: loxerror.ErrUnterminatedString},
-			},
-		},
-		{
 			input: "1234",
 			expected: []token.Token{
 				{Line: 0, Lexeme: "1234", Literal: float64(1234), Type: token.NUMBER},
@@ -74,23 +67,6 @@ func TestScanTokens(t *testing.T) {
 			expected: []token.Token{
 				{Line: 1, Lexeme: "!=", Type: token.BANG_EQUAL},
 				{Line: 1, Type: token.EOF},
-			},
-		},
-		{
-			testName: "error: invalid character",
-			input:    "@",
-			expected: nil,
-			expectedErrors: []loxerror.LoxError{
-				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
-			},
-		},
-		{
-			testName: "error: invalid characters (multiline)",
-			input:    "@\n$",
-			expected: nil,
-			expectedErrors: []loxerror.LoxError{
-				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
-				{Line: 1, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '$')},
 			},
 		},
 		{
@@ -323,6 +299,30 @@ func TestScanTokens(t *testing.T) {
 				{Line: 6, Lexeme: "}", Type: token.RIGHT_BRACE},
 
 				{Line: 7, Type: token.EOF},
+			},
+		},
+		{
+			testName: "error: unterminated string",
+			input:    "\"",
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: loxerror.ErrUnterminatedString},
+			},
+		},
+		{
+			testName: "error: invalid character",
+			input:    "@",
+			expected: nil,
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
+			},
+		},
+		{
+			testName: "error: invalid characters (multiline)",
+			input:    "@\n$",
+			expected: nil,
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
+				{Line: 1, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '$')},
 			},
 		},
 	}

--- a/golox/scanner/scanner_test.go
+++ b/golox/scanner/scanner_test.go
@@ -54,11 +54,72 @@ func TestScanTokens(t *testing.T) {
 			},
 		},
 		{
+			input: "1*2 >= 3*4",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
+				{Line: 0, Lexeme: "*", Type: token.STAR},
+				{Line: 0, Lexeme: "2", Literal: float64(2), Type: token.NUMBER},
+				{Line: 0, Lexeme: ">=", Type: token.GREATER_EQUAL},
+				{Line: 0, Lexeme: "3", Literal: float64(3), Type: token.NUMBER},
+				{Line: 0, Lexeme: "*", Type: token.STAR},
+				{Line: 0, Lexeme: "4", Literal: float64(4), Type: token.NUMBER},
+
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "-12/0.34",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "-", Type: token.MINUS},
+				{Line: 0, Lexeme: "12", Literal: float64(12), Type: token.NUMBER},
+				{Line: 0, Lexeme: "/", Type: token.SLASH},
+				{Line: 0, Lexeme: "0.34", Literal: 0.34, Type: token.NUMBER},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
 			input: "1 != 2",
 			expected: []token.Token{
 				{Line: 0, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
 				{Line: 0, Lexeme: "!=", Type: token.BANG_EQUAL},
 				{Line: 0, Lexeme: "2", Literal: float64(2), Type: token.NUMBER},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "a == b",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "==", Type: token.EQUAL_EQUAL},
+				{Line: 0, Lexeme: "b", Type: token.IDENTIFIER},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "a != b",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "!=", Type: token.BANG_EQUAL},
+				{Line: 0, Lexeme: "b", Type: token.IDENTIFIER},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "a = !b",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "=", Type: token.EQUAL},
+				{Line: 0, Lexeme: "!", Type: token.BANG},
+				{Line: 0, Lexeme: "b", Type: token.IDENTIFIER},
+				{Line: 0, Type: token.EOF},
+			},
+		},
+		{
+			input: "a > b",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "a", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: ">", Type: token.GREATER},
+				{Line: 0, Lexeme: "b", Type: token.IDENTIFIER},
 				{Line: 0, Type: token.EOF},
 			},
 		},

--- a/golox/scanner/scanner_test.go
+++ b/golox/scanner/scanner_test.go
@@ -1,0 +1,119 @@
+package scanner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/doeg/golox/golox/loxerror"
+	"github.com/doeg/golox/golox/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanTokens(t *testing.T) {
+	tests := []struct {
+		testName       string
+		input          string
+		expected       []token.Token
+		expectedErrors []loxerror.LoxError
+	}{
+		{
+			input: "( )",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "(", Type: token.LEFT_PAREN},
+				{Line: 0, Lexeme: ")", Type: token.RIGHT_PAREN},
+			},
+		},
+		{
+			input: "\"string literal\"",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "\"string literal\"", Literal: "string literal", Type: token.STRING},
+			},
+		},
+		{
+			input: "\"multiline\nstring\"",
+			expected: []token.Token{
+				{Line: 1, Lexeme: "\"multiline\nstring\"", Literal: "multiline\nstring", Type: token.STRING},
+			},
+		},
+		{
+			testName: "unterminated string",
+			input:    "\"",
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: loxerror.ErrUnterminatedString},
+			},
+		},
+		{
+			input: "1234",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "1234", Literal: float64(1234), Type: token.NUMBER},
+			},
+		},
+		{
+			input: "12.34",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "12.34", Literal: 12.34, Type: token.NUMBER},
+			},
+		},
+		{
+			input: "1 != 2",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "1", Literal: float64(1), Type: token.NUMBER},
+				{Line: 0, Lexeme: "!=", Type: token.BANG_EQUAL},
+				{Line: 0, Lexeme: "2", Literal: float64(2), Type: token.NUMBER},
+			},
+		},
+		{
+			input: "// this is a comment\n!=",
+			expected: []token.Token{
+				{Line: 1, Lexeme: "!=", Type: token.BANG_EQUAL},
+			},
+		},
+		{
+			testName: "invalid character",
+			input:    "@",
+			expected: nil,
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
+			},
+		},
+		{
+			testName: "invalid characters (multiline)",
+			input:    "@\n$",
+			expected: nil,
+			expectedErrors: []loxerror.LoxError{
+				{Line: 0, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '@')},
+				{Line: 1, Message: fmt.Sprintf(loxerror.ErrUnexpectedCharacter, '$')},
+			},
+		},
+		{
+			input: "var language = \"lox\";",
+			expected: []token.Token{
+				{Line: 0, Lexeme: "var", Type: token.VAR},
+				{Line: 0, Lexeme: "language", Type: token.IDENTIFIER},
+				{Line: 0, Lexeme: "=", Type: token.EQUAL},
+				{Line: 0, Lexeme: "\"lox\"", Literal: "lox", Type: token.STRING},
+				{Line: 0, Lexeme: ";", Type: token.SEMICOLON},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.testName
+		if tt.testName == "" {
+			testName = tt.input
+		}
+
+		t.Run(testName, func(t *testing.T) {
+			scanner := New([]byte(tt.input))
+			tokens, errors := scanner.ScanTokens()
+
+			switch {
+			case len(tt.expectedErrors) > 0:
+				assert.EqualValues(t, tt.expectedErrors, errors)
+			default:
+				assert.EqualValues(t, tt.expected, tokens)
+				assert.Empty(t, errors)
+			}
+		})
+	}
+}

--- a/golox/token/token.go
+++ b/golox/token/token.go
@@ -1,0 +1,80 @@
+package token
+
+type Token struct {
+	Lexeme  string
+	Line    int
+	Literal interface{}
+	Type    TokenType
+}
+
+type TokenType int
+
+const (
+	// Single character tokens
+	LEFT_PAREN TokenType = iota
+	RIGHT_PAREN
+	LEFT_BRACE
+	RIGHT_BRACE
+	COMMA
+	DOT
+	MINUS
+	PLUS
+	SEMICOLON
+	SLASH
+	STAR
+
+	// One or two character tokens
+	BANG
+	BANG_EQUAL
+	EQUAL
+	EQUAL_EQUAL
+	GREATER
+	GREATER_EQUAL
+	LESS
+	LESS_EQUAL
+
+	// Literals
+	IDENTIFIER
+	STRING
+	NUMBER
+
+	// Keywords
+	AND
+	CLASS
+	ELSE
+	FALSE
+	FUN
+	FOR
+	IF
+	NIL
+	OR
+	PRINT
+	RETURN
+	SUPER
+	THIS
+	TRUE
+	VAR
+	WHILE
+
+	EOF
+)
+
+// Keywords maps of reserved keyword strings to their TokenType
+var Keywords = map[string]TokenType{
+	"and":    AND,
+	"class":  CLASS,
+	"else":   ELSE,
+	"false":  FALSE,
+	"for":    FOR,
+	"fun":    FUN,
+	"if":     IF,
+	"nil":    NIL,
+	"or":     OR,
+	"print":  PRINT,
+	"return": RETURN,
+	"super":  SUPER,
+	"this":   THIS,
+	"true":   TRUE,
+	"var":    VAR,
+	"while":  WHILE,
+}


### PR DESCRIPTION
This implements the scanner described in Chapter 4 of [Crafting Interpreters](https://github.com/munificent/craftinginterpreters). A few notes and caveats:

- I left out the `cmd/` entrypoints for interpreting a file and from stdin, mostly because tests are a much more efficient way to play with the language so far.

- There are some edge cases I haven't tested yet, such as weird numerics (`.12`, `12.`) and testing the terminating `\x00` in `peekNext`. 

- I'm interested in the challenge to add `/* ... */` block comments, but will leave that for later. 