### PR TITLE
Add a first pass at expression parsing with parser.go

### DIFF
--- a/golox/parser/parser.go
+++ b/golox/parser/parser.go
@@ -1,0 +1,438 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/doeg/golox/golox/ast"
+	"github.com/doeg/golox/golox/token"
+)
+
+var (
+	ErrExpectClosingParen = "expect ')' after expression"
+	ErrExpectExpression   = "expect expression"
+)
+
+// Parser implements Lox's grammar rules as a collection of methods.
+// Each method for parsing a grammar rule produces a syntax tree for that
+// rule and returns it to the caller.
+type Parser struct {
+	tokens []*token.Token
+
+	// current points to the next token to be parsed
+	current int
+}
+
+func New(tokens []*token.Token) *Parser {
+	return &Parser{
+		current: 0,
+		tokens:  tokens,
+	}
+}
+
+func (p *Parser) Parse() (ast.Expr, error) {
+	expr, err := p.expression()
+	if err != nil {
+		// TODO check if instance of LoxParseError
+		// TODO the book returns nil here :thinking:
+		return nil, err
+	}
+	return expr, nil
+}
+
+// advance consumes the current token and returns it
+func (p *Parser) advance() (*token.Token, error) {
+	done, err := p.isAtEnd()
+	if err != nil {
+		return nil, err
+	}
+
+	if !done {
+		p.current++
+	}
+
+	return p.previous()
+}
+
+// check returns true if the current token is of the given type.
+// Unlike match, it never consumes the token, it only looks at it.
+func (p *Parser) check(tokenType token.TokenType) (bool, error) {
+	done, err := p.isAtEnd()
+	if err != nil {
+		return false, err
+	}
+
+	if done {
+		return false, nil
+	}
+
+	nextToken, err := p.peek()
+	if err != nil {
+		return false, err
+	}
+
+	return nextToken.Type == tokenType, nil
+}
+
+// comparison implements the following grammar rule:
+//
+//	comparison -> term ( ( ">" | ">=" | "<" | "<=" ) term)* ;
+func (p *Parser) comparison() (ast.Expr, error) {
+	expr, err := p.term()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		isMatch, err := p.match(token.GREATER, token.GREATER_EQUAL, token.LESS, token.LESS_EQUAL)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isMatch {
+			break
+		}
+
+		operator, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := p.term()
+		if err != nil {
+			return nil, err
+		}
+
+		expr = &ast.Binary{
+			Left:     expr,
+			Operator: operator,
+			Right:    right,
+		}
+	}
+
+	return expr, nil
+}
+
+// consume checks to see if the next token is of the expected type.
+// If so, it consumes the token. If some other token is there, then we've
+// hit an error.
+func (p *Parser) consume(tokenType token.TokenType, message string) error {
+	isMatch, err := p.check(tokenType)
+	if err != nil {
+		return err
+	}
+
+	if !isMatch {
+		return errors.New(message)
+	}
+
+	_, err = p.advance()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// equality implements the following grammar rule:
+//
+//	equality -> comparison ( ( "!=" | "==" ) comparison )* ;
+func (p *Parser) equality() (ast.Expr, error) {
+	expr, err := p.comparison()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		isMatch, err := p.match(token.BANG_EQUAL, token.EQUAL_EQUAL)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isMatch {
+			break
+		}
+
+		operator, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := p.comparison()
+		if err != nil {
+			return nil, err
+		}
+
+		expr = &ast.Binary{
+			Left:     expr,
+			Operator: operator,
+			Right:    right,
+		}
+	}
+
+	return expr, nil
+}
+
+// expression implements the following grammar rule:
+//
+//	expression -> equality ;
+func (p *Parser) expression() (ast.Expr, error) {
+	return p.equality()
+}
+
+// factor implements the following grammar rule:
+//
+//	factor -> unary ( ( "/" | "*" ) unary )* ;
+func (p *Parser) factor() (ast.Expr, error) {
+	expr, err := p.unary()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		isMatch, err := p.match(token.SLASH, token.STAR)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isMatch {
+			break
+		}
+
+		operator, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := p.factor()
+		if err != nil {
+			return nil, err
+		}
+
+		expr = &ast.Binary{
+			Left:     expr,
+			Operator: operator,
+			Right:    right,
+		}
+	}
+
+	return expr, nil
+}
+
+// get returns a pointer to the Token at the given index.
+func (p *Parser) get(index int) (*token.Token, error) {
+	if index < 0 || index >= len(p.tokens) {
+		return nil, fmt.Errorf("index %d out of bounds", index)
+	}
+
+	return p.tokens[index], nil
+}
+
+func (p *Parser) isAtEnd() (bool, error) {
+	nextToken, err := p.peek()
+	if err != nil {
+		return false, err
+	}
+
+	return nextToken.Type == token.EOF, nil
+}
+
+// match checks to see if the current token has any of the given types.
+// If so, it consumes the token and returns `true`. Otherwise, it returns `false`
+// and leaves the current token alone.
+func (p *Parser) match(tokenTypes ...token.TokenType) (bool, error) {
+	for _, tokenType := range tokenTypes {
+		isMatch, err := p.check(tokenType)
+		if err != nil {
+			return false, err
+		}
+
+		if isMatch {
+			p.advance()
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// peek is a one-token lookahead, returning the current token without consuming it.
+func (p *Parser) peek() (*token.Token, error) {
+	return p.get(p.current)
+}
+
+func (p *Parser) previous() (*token.Token, error) {
+	return p.get(p.current - 1)
+}
+
+// primary implements the following grammar rule:
+//
+//	primary -> 	NUMBER | STRING | "true" | "false" | "nil"
+//				| "(" expression ")" ;
+func (p *Parser) primary() (ast.Expr, error) {
+	isMatch, err := p.match(token.FALSE)
+	if err != nil {
+		return nil, err
+	} else if isMatch {
+		return &ast.Literal{Value: false}, nil
+	}
+
+	isMatch, err = p.match(token.TRUE)
+	if err != nil {
+		return nil, err
+	} else if isMatch {
+		return &ast.Literal{Value: true}, nil
+	}
+
+	isMatch, err = p.match(token.NIL)
+	if err != nil {
+		return nil, err
+	} else if isMatch {
+		return &ast.Literal{Value: nil}, nil
+	}
+
+	isMatch, err = p.match(token.NUMBER, token.STRING)
+	if err != nil {
+		return nil, err
+	} else if isMatch {
+		prev, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.Literal{Value: prev.Literal}, err
+	}
+
+	isMatch, err = p.match(token.LEFT_PAREN)
+	if err != nil {
+		return nil, err
+	} else if isMatch {
+		expr, err := p.expression()
+		if err != nil {
+			return nil, err
+		}
+
+		err = p.consume(token.RIGHT_PAREN, ErrExpectClosingParen)
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.Grouping{
+			Expression: expr,
+		}, nil
+	}
+
+	// TODO return a LoxError instead of a regular error for unrecognized type
+	return nil, errors.New(ErrExpectExpression)
+}
+
+// synchronize discards tokens until we're at the beginning of a new statement.
+func (p *Parser) synchronize() error {
+	_, err := p.advance()
+	if err != nil {
+		return err
+	}
+
+	for {
+		atEnd, err := p.isAtEnd()
+		if err != nil {
+			return err
+		}
+
+		if atEnd {
+			return nil
+		}
+
+		prev, err := p.previous()
+		if err != nil {
+			return err
+		}
+
+		if prev.Type == token.SEMICOLON {
+			return nil
+		}
+
+		nextToken, err := p.peek()
+		if err != nil {
+			return err
+		}
+
+		switch nextToken.Type {
+		case token.CLASS, token.FOR, token.FUN, token.IF, token.PRINT, token.RETURN, token.VAR, token.WHILE:
+			return nil
+		}
+
+		_, err = p.advance()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// term implements the following grammar rule:
+//
+//	factor ( ( "-" | "+" ) factor )* ;
+func (p *Parser) term() (ast.Expr, error) {
+	expr, err := p.factor()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		isMatch, err := p.match(token.MINUS, token.PLUS)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isMatch {
+			break
+		}
+
+		operator, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := p.factor()
+		if err != nil {
+			return nil, err
+		}
+
+		expr = &ast.Binary{
+			Left:     expr,
+			Operator: operator,
+			Right:    right,
+		}
+	}
+
+	return expr, nil
+}
+
+// unary implements the following grammar rule:
+//
+//	unary -> ( "!" | "-" ) unary
+//		 	 | primary
+func (p *Parser) unary() (ast.Expr, error) {
+	isMatch, err := p.match(token.BANG, token.MINUS)
+	if err != nil {
+		return nil, err
+	}
+
+	if isMatch {
+		operator, err := p.previous()
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := p.unary()
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.Unary{
+			Operator: operator,
+			Right:    right,
+		}, nil
+	}
+
+	return p.primary()
+}

--- a/golox/parser/parser_test.go
+++ b/golox/parser/parser_test.go
@@ -1,0 +1,229 @@
+package parser
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/doeg/golox/golox/ast"
+	"github.com/doeg/golox/golox/scanner"
+	"github.com/doeg/golox/golox/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		testName      string
+		input         string
+		expected      ast.Expr
+		expectedError error
+	}{
+		{
+			input:    "123",
+			expected: &ast.Literal{Value: float64(123)},
+		},
+		{
+			input:    "\"hello, world\"",
+			expected: &ast.Literal{Value: "hello, world"},
+		},
+		{
+			input:    "true",
+			expected: &ast.Literal{Value: true},
+		},
+		{
+			input:    "false",
+			expected: &ast.Literal{Value: false},
+		},
+		{
+			input:    "nil",
+			expected: &ast.Literal{Value: nil},
+		},
+		{
+			input: "-1",
+			expected: &ast.Unary{
+				Operator: &token.Token{
+					Lexeme: "-",
+					Line:   0,
+					Type:   token.MINUS,
+				},
+				Right: &ast.Literal{Value: float64(1)},
+			},
+		},
+		{
+			input: "5 - 3 - 1",
+			expected: &ast.Binary{
+				Left: &ast.Binary{
+					Left: &ast.Literal{
+						Value: float64(5),
+					},
+					Operator: &token.Token{
+						Lexeme: "-",
+						Line:   0,
+						Type:   token.MINUS,
+					},
+					Right: &ast.Literal{
+						Value: float64(3),
+					},
+				},
+				Operator: &token.Token{
+					Lexeme: "-",
+					Line:   0,
+					Type:   token.MINUS,
+				},
+				Right: &ast.Literal{
+					Value: float64(1),
+				},
+			},
+		},
+		{
+			input: "5 - 3 * 1",
+			expected: &ast.Binary{
+				Left: &ast.Literal{
+					Value: float64(5),
+				},
+				Operator: &token.Token{
+					Lexeme: "-",
+					Line:   0,
+					Type:   token.MINUS,
+				},
+				Right: &ast.Binary{
+					Left: &ast.Literal{
+						Value: float64(3),
+					},
+					Operator: &token.Token{
+						Lexeme: "*",
+						Line:   0,
+						Type:   token.STAR,
+					},
+					Right: &ast.Literal{
+						Value: float64(1),
+					},
+				},
+			},
+		},
+		{
+			input: "(5 - 3) * 1",
+			expected: &ast.Binary{
+				Left: &ast.Grouping{
+					Expression: &ast.Binary{
+						Left: &ast.Literal{
+							Value: float64(5),
+						},
+						Operator: &token.Token{
+							Lexeme: "-",
+							Line:   0,
+							Type:   token.MINUS,
+						},
+						Right: &ast.Literal{
+							Value: float64(3),
+						},
+					},
+				},
+				Operator: &token.Token{
+					Lexeme: "*",
+					Line:   0,
+					Type:   token.STAR,
+				},
+				Right: &ast.Literal{
+					Value: float64(1),
+				},
+			},
+		},
+		{
+			input: "-69 < 420 == true",
+			expected: &ast.Binary{
+				Left: &ast.Binary{
+					Left: &ast.Unary{
+						Operator: &token.Token{
+							Lexeme: "-",
+							Line:   0,
+							Type:   token.MINUS,
+						},
+						Right: &ast.Literal{Value: float64(69)},
+					},
+					Operator: &token.Token{
+						Lexeme: "<",
+						Line:   0,
+						Type:   token.LESS,
+					},
+					Right: &ast.Literal{
+						Value: float64(420),
+					},
+				},
+				Operator: &token.Token{
+					Lexeme: "==",
+					Line:   0,
+					Type:   token.EQUAL_EQUAL,
+				},
+				Right: &ast.Literal{Value: true},
+			},
+		},
+		{
+			testName:      "error: expected expression",
+			input:         "* 1",
+			expectedError: errors.New(ErrExpectExpression),
+		},
+		{
+			testName:      "error: missing closing paren",
+			input:         "(1",
+			expectedError: errors.New(ErrExpectClosingParen),
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.testName
+		if tt.testName == "" {
+			testName = tt.input
+		}
+
+		tt := tt
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			s := scanner.New([]byte(tt.input))
+			tokens, errors := s.ScanTokens()
+			require.Empty(t, errors)
+
+			p := New(tokens)
+			expr, err := p.Parse()
+
+			if tt.expectedError != nil {
+				assert.Nil(t, expr)
+				assert.Equal(t, tt.expectedError, err)
+			} else {
+				assert.EqualValues(t, tt.expected, expr)
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestSynchronize(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedIndex int
+	}{
+		{
+			input:         "(1 + 2; 3;",
+			expectedIndex: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			s := scanner.New([]byte(tt.input))
+			tokens, errors := s.ScanTokens()
+			require.Empty(t, errors)
+
+			p := New(tokens)
+			err := p.synchronize()
+			require.Nil(t, err)
+
+			assert.Equal(t, tt.expectedIndex, p.current)
+		})
+	}
+}


### PR DESCRIPTION
Mapping this chapter onto Go was a little frustrating, and that's entirely because (heavy sigh) error handling. My implementation diverges in a handful of ways:

- The book leans on Java's throwable exceptions to trigger "panic mode", which will cause the parser to `synchronize` itself and (ideally) carry on. In Go, this _could_ be done with `panic` and `recover`, and... maybe it should...? Maybe it must? But given that we've not yet implemented statements, I'm not sure how I want this to look yet. So... will absolutely be coming back to this later. 🤡 Unfortunately. 

- The book seems to ignore certain edge cases, like trying to access `tokens[idx]` for some invalid `idx`. Specifically, it accesses its `tokens` list with the List's `get` method, which will throw an `IndexOutOfBoundsException` exception when... well, you know. In this case, Go will panic, which is... similar? I guess? And maybe this loops back to the above point on co-opting `panic`/`recover` for this... 🤔 In the meantime, I'm just passing `error`s around. Not even `LoxError`s, just... `errors`. 

- The book's `Parse` function will trap syntax errors and return `nil`, since:
    1. Its `Parser` class has an `error` method that calls `Lox.error` to report the syntax error(s)
    2. As the book states: "The parser promises to not crash or hang on invalid syntax, but it doesn't promise to return a usable syntax tree if an error is found. As soon as the parser reports an error, `hadError` gets set and subsequent phases are skipped." 

  The book's `Lox` class is equivalent to my `cmd/golox` interpreter entrypoint, which I haven't implemented yet. (So far, the only way I've been "using" the language is via tests; I don't see much point in implementing a REPL or file entrypoint until we can actually evaluate stuff.) Another thing to come back to. 