### PR TITLE
Refactor AST to support public Visitor methods and (any, error) returns 

### DIFF
--- a/cmd/golox-ast/ast.go.tmpl
+++ b/cmd/golox-ast/ast.go.tmpl
@@ -7,12 +7,12 @@ import(
 
 type Visitor interface {
 	{{- range .VisitorFunctions }}
-	visit{{ . }}{{ $.BaseInterface }}(expr *{{ . }}) any
+	Visit{{ . }}{{ $.BaseInterface }}(expr *{{ . }}) (any, error)
 	{{- end }}
 }
 
-type {{.BaseInterface}} interface{
-	accept(Visitor) any
+type {{.BaseInterface}} interface {
+	Accept(Visitor) (any, error)
 }
 
 {{ range .Types }}
@@ -22,7 +22,7 @@ type {{ .StructName }} struct {
 	{{- end }}
 }
 
-func (e *{{ .StructName }}) accept(v Visitor) any {
-	return v.visit{{ .StructName }}{{ $.BaseInterface }}(e)
+func (e *{{ .StructName }}) Accept(v Visitor) (any, error) {
+	return v.Visit{{ .StructName }}{{ $.BaseInterface }}(e)
 }
 {{ end }}

--- a/golox/ast/ast.go
+++ b/golox/ast/ast.go
@@ -6,14 +6,14 @@ import (
 )
 
 type Visitor interface {
-	visitBinaryExpr(expr *Binary) any
-	visitGroupingExpr(expr *Grouping) any
-	visitLiteralExpr(expr *Literal) any
-	visitUnaryExpr(expr *Unary) any
+	VisitBinaryExpr(expr *Binary) (any, error)
+	VisitGroupingExpr(expr *Grouping) (any, error)
+	VisitLiteralExpr(expr *Literal) (any, error)
+	VisitUnaryExpr(expr *Unary) (any, error)
 }
 
 type Expr interface {
-	accept(Visitor) any
+	Accept(Visitor) (any, error)
 }
 
 type Binary struct {
@@ -22,24 +22,24 @@ type Binary struct {
 	Right    Expr
 }
 
-func (e *Binary) accept(v Visitor) any {
-	return v.visitBinaryExpr(e)
+func (e *Binary) Accept(v Visitor) (any, error) {
+	return v.VisitBinaryExpr(e)
 }
 
 type Grouping struct {
 	Expression Expr
 }
 
-func (e *Grouping) accept(v Visitor) any {
-	return v.visitGroupingExpr(e)
+func (e *Grouping) Accept(v Visitor) (any, error) {
+	return v.VisitGroupingExpr(e)
 }
 
 type Literal struct {
 	Value interface{}
 }
 
-func (e *Literal) accept(v Visitor) any {
-	return v.visitLiteralExpr(e)
+func (e *Literal) Accept(v Visitor) (any, error) {
+	return v.VisitLiteralExpr(e)
 }
 
 type Unary struct {
@@ -47,6 +47,6 @@ type Unary struct {
 	Right    Expr
 }
 
-func (e *Unary) accept(v Visitor) any {
-	return v.visitUnaryExpr(e)
+func (e *Unary) Accept(v Visitor) (any, error) {
+	return v.VisitUnaryExpr(e)
 }

--- a/golox/ast/astprinter.go
+++ b/golox/ast/astprinter.go
@@ -8,35 +8,40 @@ import (
 type ASTPrinter struct{}
 
 func (p *ASTPrinter) Print(expr Expr) string {
-	result := expr.accept(p).(string)
-	return result
+	result, _ := expr.Accept(p)
+	return result.(string)
 }
 
-func (p *ASTPrinter) parenthesize(name string, exprs ...Expr) string {
+func (p *ASTPrinter) parenthesize(name string, exprs ...Expr) (string, error) {
 	strs := make([]string, 0)
 	for _, expr := range exprs {
-		strs = append(strs, expr.accept(p).(string))
+		s, err := expr.Accept(p)
+		if err != nil {
+			return "", err
+		}
+
+		strs = append(strs, s.(string))
 	}
 
-	return fmt.Sprintf("(%s %s)", name, strings.Join(strs, " "))
+	return fmt.Sprintf("(%s %s)", name, strings.Join(strs, " ")), nil
 }
 
-func (p *ASTPrinter) visitBinaryExpr(expr *Binary) any {
+func (p *ASTPrinter) VisitBinaryExpr(expr *Binary) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right)
 }
 
-func (p *ASTPrinter) visitGroupingExpr(expr *Grouping) any {
+func (p *ASTPrinter) VisitGroupingExpr(expr *Grouping) (any, error) {
 	return p.parenthesize("group", expr.Expression)
 }
 
-func (p *ASTPrinter) visitLiteralExpr(expr *Literal) any {
+func (p *ASTPrinter) VisitLiteralExpr(expr *Literal) (any, error) {
 	if expr.Value == nil {
-		return "nil"
+		return nil, nil
 	}
 
-	return fmt.Sprintf("%+v", expr.Value)
+	return fmt.Sprintf("%+v", expr.Value), nil
 }
 
-func (p *ASTPrinter) visitUnaryExpr(expr *Unary) any {
+func (p *ASTPrinter) VisitUnaryExpr(expr *Unary) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Right)
 }

--- a/golox/ast/astprinter/astprinter.go
+++ b/golox/ast/astprinter/astprinter.go
@@ -3,16 +3,18 @@ package ast
 import (
 	"fmt"
 	"strings"
+
+	"github.com/doeg/golox/golox/ast"
 )
 
 type ASTPrinter struct{}
 
-func (p *ASTPrinter) Print(expr Expr) string {
+func (p *ASTPrinter) Print(expr ast.Expr) string {
 	result, _ := expr.Accept(p)
 	return result.(string)
 }
 
-func (p *ASTPrinter) parenthesize(name string, exprs ...Expr) (string, error) {
+func (p *ASTPrinter) parenthesize(name string, exprs ...ast.Expr) (string, error) {
 	strs := make([]string, 0)
 	for _, expr := range exprs {
 		s, err := expr.Accept(p)
@@ -26,15 +28,15 @@ func (p *ASTPrinter) parenthesize(name string, exprs ...Expr) (string, error) {
 	return fmt.Sprintf("(%s %s)", name, strings.Join(strs, " ")), nil
 }
 
-func (p *ASTPrinter) VisitBinaryExpr(expr *Binary) (any, error) {
+func (p *ASTPrinter) VisitBinaryExpr(expr *ast.Binary) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right)
 }
 
-func (p *ASTPrinter) VisitGroupingExpr(expr *Grouping) (any, error) {
+func (p *ASTPrinter) VisitGroupingExpr(expr *ast.Grouping) (any, error) {
 	return p.parenthesize("group", expr.Expression)
 }
 
-func (p *ASTPrinter) VisitLiteralExpr(expr *Literal) (any, error) {
+func (p *ASTPrinter) VisitLiteralExpr(expr *ast.Literal) (any, error) {
 	if expr.Value == nil {
 		return nil, nil
 	}
@@ -42,6 +44,6 @@ func (p *ASTPrinter) VisitLiteralExpr(expr *Literal) (any, error) {
 	return fmt.Sprintf("%+v", expr.Value), nil
 }
 
-func (p *ASTPrinter) VisitUnaryExpr(expr *Unary) (any, error) {
+func (p *ASTPrinter) VisitUnaryExpr(expr *ast.Unary) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Right)
 }

--- a/golox/ast/astprinter/astprinter_test.go
+++ b/golox/ast/astprinter/astprinter_test.go
@@ -3,24 +3,25 @@ package ast
 import (
 	"testing"
 
+	"github.com/doeg/golox/golox/ast"
 	"github.com/doeg/golox/golox/token"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestASTPrinter(t *testing.T) {
 	tests := []struct {
-		input    Expr
+		input    ast.Expr
 		expected string
 	}{
 		{
-			input: &Binary{
-				Left: &Unary{
+			input: &ast.Binary{
+				Left: &ast.Unary{
 					Operator: &token.Token{
 						Lexeme: "-",
 						Line:   1,
 						Type:   token.MINUS,
 					},
-					Right: &Literal{
+					Right: &ast.Literal{
 						Value: 123,
 					},
 				},
@@ -29,8 +30,8 @@ func TestASTPrinter(t *testing.T) {
 					Line:   1,
 					Type:   token.STAR,
 				},
-				Right: &Grouping{
-					Expression: &Literal{
+				Right: &ast.Grouping{
+					Expression: &ast.Literal{
 						Value: 45.67,
 					},
 				},


### PR DESCRIPTION
A bit of refactoring on the AST. ✨🧹

- When implementing the interpreter, which itself implements the Visitor interface, I ran into trouble with this in particular:

  ```
  func (i *Interpreter) evaluate(expr *ast.Expr) any {
    return expr.accept(i)
  }
  ```
   The issue here is that the `accept` method on the `Interpreter` struct is hidden from `expr`. This wasn't an issue with the proof-of-concept `ASTPrinter`, since it was in `package ast` alongside the generated `ast.go`. To avoid this, I moved `astprinter` into its own package and made sure all of the methods in the AST are public. 

- I realized there's utility in allowing Visitor implementations to support the standard two-value return `(any, error)`. Error handling..................... is never fun to think about. 