### PR TITLE
Add a REPL entrypoint to cmd/golox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ generate:
 install:
 	go install ./...
 
+.PHONY: repl
+repl: build
+	./build/golox	
+
 .PHONY: test
 test:
 	go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ golox is a tree-walk interpreter for the [Lox programming language](https://gith
 
 ## Local development
 
+To start a REPL:
+
+```
+make repl
+```
+
 To build the binaries and make them globally available:
 
 ```

--- a/cmd/golox/main.go
+++ b/cmd/golox/main.go
@@ -1,8 +1,48 @@
 package main
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/doeg/golox/golox/interpreter"
+	"github.com/doeg/golox/golox/parser"
+	"github.com/doeg/golox/golox/scanner"
+)
 
 func main() {
-	greeting := "Hello world!"
-	fmt.Println(greeting)
+	repl()
+}
+
+func repl() {
+	for {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("> ")
+		text, _ := reader.ReadString('\n')
+
+		s := scanner.New([]byte(text))
+		tokens, errs := s.ScanTokens()
+		if len(errs) > 0 {
+			for _, err := range errs {
+				fmt.Println(err.Error())
+			}
+			continue
+		}
+
+		p := parser.New(tokens)
+		expr, err := p.Parse()
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		i := interpreter.New()
+		result, err := i.Interpret(expr)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		fmt.Printf("%+v\n", result)
+	}
 }


### PR DESCRIPTION
It's cute! As long as you ignore the inconsistent error handling, which I shall. 😌 

```bash
$ make repl
go build -o build/ ./...
./build/golox	
> "hello" + " " + "world"
hello world
> 1 + 2
3
> 5 + "nope"
operators must be strings or numbers
> fjsdghsdg(
expect expression
> 90/0
+Inf
> 5 % 2
[line 0] Error: unexpected character 25

> ^Cmake: *** [repl] Interrupt: 2
```
