### PR TITLE
Rewrite golox-ast generator to use *Expr suffix

### DIFF
--- a/cmd/golox-ast/ast.go.tmpl
+++ b/cmd/golox-ast/ast.go.tmpl
@@ -5,24 +5,29 @@ import(
 	"github.com/doeg/golox/golox/token"
 )
 
-type Visitor interface {
-	{{- range .VisitorFunctions }}
-	Visit{{ . }}{{ $.BaseInterface }}(expr *{{ . }}) (any, error)
-	{{- end }}
-}
+{{ range .Interfaces }}
 
-type {{.BaseInterface}} interface {
-	Accept(Visitor) (any, error)
-}
+	{{ $interface := . }}
 
-{{ range .Types }}
-type {{ .StructName }} struct {
-	{{- range .Fields }}
-	{{ .Name | ToTitle }} {{ .Type }}
-	{{- end }}
-}
+	type {{ .BaseInterface }}Visitor interface {
+		{{- range .VisitorFunctions }}
+			Visit{{ . }}{{ $interface.BaseInterface }}(expr *{{ . }}{{ $interface.BaseInterface }}) (any, error)
+		{{- end }}
+	}
 
-func (e *{{ .StructName }}) Accept(v Visitor) (any, error) {
-	return v.Visit{{ .StructName }}{{ $.BaseInterface }}(e)
-}
+	type {{.BaseInterface}} interface {
+		Accept({{ .BaseInterface }}Visitor) (any, error)
+	}
+
+	{{ range .Types }}
+		type {{ .StructName }}{{ $interface.BaseInterface }} struct {
+			{{- range .Fields }}
+			{{ .Name | ToTitle }} {{ .Type }}
+			{{- end }}
+		}
+
+		func (e *{{ .StructName }}{{ $interface.BaseInterface }}) Accept(v {{ $interface.BaseInterface }}Visitor) (any, error) {
+			return v.Visit{{ .StructName }}{{ $interface.BaseInterface }}(e)
+		}
+	{{ end }}
 {{ end }}

--- a/cmd/golox-ast/main.go
+++ b/cmd/golox-ast/main.go
@@ -5,48 +5,29 @@ package main
 import (
 	"bytes"
 	_ "embed"
-	"flag"
 	"go/format"
+	"html/template"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
-	"text/template"
 )
 
-var outputFlag = flag.String("output", "./golox/ast/ast.go", "a filepath for the generated output")
-
-var ast = []string{
-	"Binary		:	Expr left, Token operator, Expr right",
-	"Grouping	:	Expr expression",
-	"Literal	:	Object value",
-	"Unary		:	Token operator, Expr right",
-}
-
+// Embed the ast.go template file so that we don't have to mess with
+// file I/O, relative pathnames, etc. etc.
+//
 //go:embed ast.go.tmpl
 var tmpl string
 
-func main() {
-	flag.Parse()
-
-	abs, err := filepath.Abs(*outputFlag)
-	if err != nil {
-		panic(err)
-	}
-
-	os.MkdirAll(filepath.Dir(abs), 0700)
-
-	f, err := os.Create(abs)
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
-
-	if err = defineAST(f, "Expr", ast); err != nil {
-		panic(err)
-	}
-}
+// The full path of the output file, relative to the project root
+const outPath string = "./golox/ast/"
+const outName string = "ast.go"
 
 type TemplateParams struct {
+	Interfaces []ASTInterface
+}
+
+type ASTInterface struct {
 	BaseInterface    string
 	Types            []ExpressionDef
 	VisitorFunctions []string
@@ -62,93 +43,102 @@ type ExpressionField struct {
 	Type string
 }
 
-// defineAST prints AST type definitions given a list of Lox grammar rules.
-func defineAST(f *os.File, baseName string, grammar []string) error {
+func main() {
+	interfaces := []ASTInterface{
+		defineAST("Expr", []string{
+			"Binary		:	Expr left, Token operator, Expr right",
+			"Grouping	:	Expr expression",
+			"Literal	:	Object value",
+			"Unary		:	Token operator, Expr right",
+		}),
+	}
+
+	t, err := template.New("golox-ast").Funcs(template.FuncMap{
+		"ToTitle": strings.Title,
+	}).Parse(tmpl)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+	if err = t.Execute(&buf, TemplateParams{
+		Interfaces: interfaces,
+	}); err != nil {
+		panic(err)
+	}
+
+	// Nicely format the go source code :)
+	p, err := format.Source(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	abs, err := filepath.Abs(outPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// The directory should pretty much _always_ exist,
+	// but recursively create it just in case we're doing something dumb.
+	os.MkdirAll(abs, 0700)
+
+	// Create the ast.go file, overwriting anything that's currently there.
+	filePath := path.Join(abs, outName)
+	f, err := os.Create(filePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	// Finally, write the formatted ast.go source to disk.
+	if _, err := f.Write(p); err != nil {
+		panic(err)
+	}
+}
+
+func defineAST(baseInterface string, rules []string) ASTInterface {
 	defs := make([]ExpressionDef, 0)
 	visitorFunctions := make([]string, 0)
 
 	// This is pretty gross but, as the book mentions, robustness
 	// ain't a priority :cowboy:
-	for _, e := range grammar {
-		parts := strings.Split(e, ":")
-
+	for _, rule := range rules {
+		parts := strings.Split(rule, ":")
 		structName := strings.TrimSpace(parts[0])
-		fields := strings.TrimSpace(parts[1])
+		fieldList := strings.Split(strings.TrimSpace(parts[1]), ",")
 
-		defs = append(defs, defineStruct(structName, fields))
+		fields := make([]ExpressionField, 0)
+		for _, fp := range fieldList {
+			p := strings.Split(strings.TrimSpace(fp), " ")
+
+			// Crafting Interpreters defines field types in a Java-ish way.
+			// For the sake of... consistency? I've decided to keep the AST definition
+			// (in its text form) exactly as the book has it. It does, however, necessitate
+			// this ugly little switch statement to exorcise the Java-isms.
+			fieldType := p[0]
+			switch fieldType {
+			case "Object":
+				fieldType = "interface{}"
+			case "Token":
+				fieldType = "*token.Token"
+			}
+
+			fields = append(fields, ExpressionField{
+				Name: p[1],
+				Type: fieldType,
+			})
+		}
+
+		defs = append(defs, ExpressionDef{
+			StructName: structName,
+			Fields:     fields,
+		})
 		visitorFunctions = append(visitorFunctions, structName)
 	}
 
-	t, err := template.New("golox-ast").Funcs(template.FuncMap{
-		// strings.Title is deprecated but it only really matters for Unicode text,
-		// which Lox is not. :)
-		"ToTitle": strings.Title,
-	}).Parse(tmpl)
-	if err != nil {
-		return err
-	}
-
-	var buf bytes.Buffer
-	if err = t.Execute(&buf, TemplateParams{
-		BaseInterface:    baseName,
+	return ASTInterface{
+		BaseInterface:    baseInterface,
 		Types:            defs,
 		VisitorFunctions: visitorFunctions,
-	}); err != nil {
-		return err
-	}
-
-	// Nicely format the go source code
-	p, err := format.Source(buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if _, err := f.Write(p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// defineStruct generates the struct name and fields for a node in the AST; for example:
-//
-//	defineStruct("Unary", "Token operator, Expr right")
-//
-// ...will return:
-//
-//	{
-//		StructName: "Unary",
-//		Fields: [
-//			{ Name: "operator", Type: "*token.Token" },
-//			{ Name: "right", Type: "Expr" },
-//		],
-//	}
-func defineStruct(structName, fieldList string) ExpressionDef {
-	fields := make([]ExpressionField, 0)
-
-	for _, fp := range strings.Split(fieldList, ",") {
-		p := strings.Split(strings.TrimSpace(fp), " ")
-
-		// Crafting Interpreters defines field types in a Java-ish way.
-		// For the sake of... consistency? I've decided to keep the AST definition
-		// (in its text form) exactly as the book has it. It does, however, necessitate
-		// this ugly little switch statement to exorcise the Java-isms.
-		fieldType := p[0]
-		switch fieldType {
-		case "Object":
-			fieldType = "interface{}"
-		case "Token":
-			fieldType = "*token.Token"
-		}
-
-		fields = append(fields, ExpressionField{
-			Name: p[1],
-			Type: fieldType,
-		})
-	}
-
-	return ExpressionDef{
-		StructName: structName,
-		Fields:     fields,
 	}
 }

--- a/golox/ast/ast.go
+++ b/golox/ast/ast.go
@@ -5,48 +5,48 @@ import (
 	"github.com/doeg/golox/golox/token"
 )
 
-type Visitor interface {
-	VisitBinaryExpr(expr *Binary) (any, error)
-	VisitGroupingExpr(expr *Grouping) (any, error)
-	VisitLiteralExpr(expr *Literal) (any, error)
-	VisitUnaryExpr(expr *Unary) (any, error)
+type ExprVisitor interface {
+	VisitBinaryExpr(expr *BinaryExpr) (any, error)
+	VisitGroupingExpr(expr *GroupingExpr) (any, error)
+	VisitLiteralExpr(expr *LiteralExpr) (any, error)
+	VisitUnaryExpr(expr *UnaryExpr) (any, error)
 }
 
 type Expr interface {
-	Accept(Visitor) (any, error)
+	Accept(ExprVisitor) (any, error)
 }
 
-type Binary struct {
+type BinaryExpr struct {
 	Left     Expr
 	Operator *token.Token
 	Right    Expr
 }
 
-func (e *Binary) Accept(v Visitor) (any, error) {
+func (e *BinaryExpr) Accept(v ExprVisitor) (any, error) {
 	return v.VisitBinaryExpr(e)
 }
 
-type Grouping struct {
+type GroupingExpr struct {
 	Expression Expr
 }
 
-func (e *Grouping) Accept(v Visitor) (any, error) {
+func (e *GroupingExpr) Accept(v ExprVisitor) (any, error) {
 	return v.VisitGroupingExpr(e)
 }
 
-type Literal struct {
+type LiteralExpr struct {
 	Value interface{}
 }
 
-func (e *Literal) Accept(v Visitor) (any, error) {
+func (e *LiteralExpr) Accept(v ExprVisitor) (any, error) {
 	return v.VisitLiteralExpr(e)
 }
 
-type Unary struct {
+type UnaryExpr struct {
 	Operator *token.Token
 	Right    Expr
 }
 
-func (e *Unary) Accept(v Visitor) (any, error) {
+func (e *UnaryExpr) Accept(v ExprVisitor) (any, error) {
 	return v.VisitUnaryExpr(e)
 }

--- a/golox/ast/astprinter/astprinter.go
+++ b/golox/ast/astprinter/astprinter.go
@@ -28,15 +28,15 @@ func (p *ASTPrinter) parenthesize(name string, exprs ...ast.Expr) (string, error
 	return fmt.Sprintf("(%s %s)", name, strings.Join(strs, " ")), nil
 }
 
-func (p *ASTPrinter) VisitBinaryExpr(expr *ast.Binary) (any, error) {
+func (p *ASTPrinter) VisitBinaryExpr(expr *ast.BinaryExpr) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Left, expr.Right)
 }
 
-func (p *ASTPrinter) VisitGroupingExpr(expr *ast.Grouping) (any, error) {
+func (p *ASTPrinter) VisitGroupingExpr(expr *ast.GroupingExpr) (any, error) {
 	return p.parenthesize("group", expr.Expression)
 }
 
-func (p *ASTPrinter) VisitLiteralExpr(expr *ast.Literal) (any, error) {
+func (p *ASTPrinter) VisitLiteralExpr(expr *ast.LiteralExpr) (any, error) {
 	if expr.Value == nil {
 		return nil, nil
 	}
@@ -44,6 +44,6 @@ func (p *ASTPrinter) VisitLiteralExpr(expr *ast.Literal) (any, error) {
 	return fmt.Sprintf("%+v", expr.Value), nil
 }
 
-func (p *ASTPrinter) VisitUnaryExpr(expr *ast.Unary) (any, error) {
+func (p *ASTPrinter) VisitUnaryExpr(expr *ast.UnaryExpr) (any, error) {
 	return p.parenthesize(expr.Operator.Lexeme, expr.Right)
 }

--- a/golox/ast/astprinter/astprinter_test.go
+++ b/golox/ast/astprinter/astprinter_test.go
@@ -14,14 +14,14 @@ func TestASTPrinter(t *testing.T) {
 		expected string
 	}{
 		{
-			input: &ast.Binary{
-				Left: &ast.Unary{
+			input: &ast.BinaryExpr{
+				Left: &ast.UnaryExpr{
 					Operator: &token.Token{
 						Lexeme: "-",
 						Line:   1,
 						Type:   token.MINUS,
 					},
-					Right: &ast.Literal{
+					Right: &ast.LiteralExpr{
 						Value: 123,
 					},
 				},
@@ -30,8 +30,8 @@ func TestASTPrinter(t *testing.T) {
 					Line:   1,
 					Type:   token.STAR,
 				},
-				Right: &ast.Grouping{
-					Expression: &ast.Literal{
+				Right: &ast.GroupingExpr{
+					Expression: &ast.LiteralExpr{
 						Value: 45.67,
 					},
 				},

--- a/golox/interpreter/interpreter.go
+++ b/golox/interpreter/interpreter.go
@@ -17,7 +17,7 @@ func (i *Interpreter) Interpret(expr ast.Expr) (any, error) {
 	return i.evaluate(expr)
 }
 
-func (i *Interpreter) VisitBinaryExpr(expr *ast.Binary) (any, error) {
+func (i *Interpreter) VisitBinaryExpr(expr *ast.BinaryExpr) (any, error) {
 	left, err := i.evaluate(expr.Left)
 	if err != nil {
 		return nil, err
@@ -97,15 +97,15 @@ func (i *Interpreter) VisitBinaryExpr(expr *ast.Binary) (any, error) {
 	return nil, errors.New("invalid binary operator")
 }
 
-func (i *Interpreter) VisitGroupingExpr(expr *ast.Grouping) (any, error) {
+func (i *Interpreter) VisitGroupingExpr(expr *ast.GroupingExpr) (any, error) {
 	return i.evaluate(expr.Expression)
 }
 
-func (i *Interpreter) VisitLiteralExpr(expr *ast.Literal) (any, error) {
+func (i *Interpreter) VisitLiteralExpr(expr *ast.LiteralExpr) (any, error) {
 	return expr.Value, nil
 }
 
-func (i *Interpreter) VisitUnaryExpr(expr *ast.Unary) (any, error) {
+func (i *Interpreter) VisitUnaryExpr(expr *ast.UnaryExpr) (any, error) {
 	// Unary expressions have a single sub-expression that we evaluate first.
 	right, err := i.evaluate(expr.Right)
 	if err != nil {

--- a/golox/interpreter/interpreter_test.go
+++ b/golox/interpreter/interpreter_test.go
@@ -342,7 +342,7 @@ func TestVisitBinaryExpression(t *testing.T) {
 			pExpr, err := p.Parse()
 			require.Nil(t, err)
 
-			expr := pExpr.(*ast.Binary)
+			expr := pExpr.(*ast.BinaryExpr)
 
 			i := New()
 			result, err := i.VisitBinaryExpr(expr)
@@ -404,7 +404,7 @@ func TestVisitUnaryExpression(t *testing.T) {
 			pExpr, err := p.Parse()
 			require.Nil(t, err)
 
-			expr := pExpr.(*ast.Unary)
+			expr := pExpr.(*ast.UnaryExpr)
 
 			i := New()
 			result, err := i.VisitUnaryExpr(expr)

--- a/golox/parser/parser.go
+++ b/golox/parser/parser.go
@@ -103,7 +103,7 @@ func (p *Parser) comparison() (ast.Expr, error) {
 			return nil, err
 		}
 
-		expr = &ast.Binary{
+		expr = &ast.BinaryExpr{
 			Left:     expr,
 			Operator: operator,
 			Right:    right,
@@ -163,7 +163,7 @@ func (p *Parser) equality() (ast.Expr, error) {
 			return nil, err
 		}
 
-		expr = &ast.Binary{
+		expr = &ast.BinaryExpr{
 			Left:     expr,
 			Operator: operator,
 			Right:    right,
@@ -209,7 +209,7 @@ func (p *Parser) factor() (ast.Expr, error) {
 			return nil, err
 		}
 
-		expr = &ast.Binary{
+		expr = &ast.BinaryExpr{
 			Left:     expr,
 			Operator: operator,
 			Right:    right,
@@ -273,21 +273,21 @@ func (p *Parser) primary() (ast.Expr, error) {
 	if err != nil {
 		return nil, err
 	} else if isMatch {
-		return &ast.Literal{Value: false}, nil
+		return &ast.LiteralExpr{Value: false}, nil
 	}
 
 	isMatch, err = p.match(token.TRUE)
 	if err != nil {
 		return nil, err
 	} else if isMatch {
-		return &ast.Literal{Value: true}, nil
+		return &ast.LiteralExpr{Value: true}, nil
 	}
 
 	isMatch, err = p.match(token.NIL)
 	if err != nil {
 		return nil, err
 	} else if isMatch {
-		return &ast.Literal{Value: nil}, nil
+		return &ast.LiteralExpr{Value: nil}, nil
 	}
 
 	isMatch, err = p.match(token.NUMBER, token.STRING)
@@ -299,7 +299,7 @@ func (p *Parser) primary() (ast.Expr, error) {
 			return nil, err
 		}
 
-		return &ast.Literal{Value: prev.Literal}, err
+		return &ast.LiteralExpr{Value: prev.Literal}, err
 	}
 
 	isMatch, err = p.match(token.LEFT_PAREN)
@@ -316,7 +316,7 @@ func (p *Parser) primary() (ast.Expr, error) {
 			return nil, err
 		}
 
-		return &ast.Grouping{
+		return &ast.GroupingExpr{
 			Expression: expr,
 		}, nil
 	}
@@ -397,7 +397,7 @@ func (p *Parser) term() (ast.Expr, error) {
 			return nil, err
 		}
 
-		expr = &ast.Binary{
+		expr = &ast.BinaryExpr{
 			Left:     expr,
 			Operator: operator,
 			Right:    right,
@@ -428,7 +428,7 @@ func (p *Parser) unary() (ast.Expr, error) {
 			return nil, err
 		}
 
-		return &ast.Unary{
+		return &ast.UnaryExpr{
 			Operator: operator,
 			Right:    right,
 		}, nil

--- a/golox/parser/parser_test.go
+++ b/golox/parser/parser_test.go
@@ -20,40 +20,40 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			input:    "123",
-			expected: &ast.Literal{Value: float64(123)},
+			expected: &ast.LiteralExpr{Value: float64(123)},
 		},
 		{
 			input:    "\"hello, world\"",
-			expected: &ast.Literal{Value: "hello, world"},
+			expected: &ast.LiteralExpr{Value: "hello, world"},
 		},
 		{
 			input:    "true",
-			expected: &ast.Literal{Value: true},
+			expected: &ast.LiteralExpr{Value: true},
 		},
 		{
 			input:    "false",
-			expected: &ast.Literal{Value: false},
+			expected: &ast.LiteralExpr{Value: false},
 		},
 		{
 			input:    "nil",
-			expected: &ast.Literal{Value: nil},
+			expected: &ast.LiteralExpr{Value: nil},
 		},
 		{
 			input: "-1",
-			expected: &ast.Unary{
+			expected: &ast.UnaryExpr{
 				Operator: &token.Token{
 					Lexeme: "-",
 					Line:   0,
 					Type:   token.MINUS,
 				},
-				Right: &ast.Literal{Value: float64(1)},
+				Right: &ast.LiteralExpr{Value: float64(1)},
 			},
 		},
 		{
 			input: "5 - 3 - 1",
-			expected: &ast.Binary{
-				Left: &ast.Binary{
-					Left: &ast.Literal{
+			expected: &ast.BinaryExpr{
+				Left: &ast.BinaryExpr{
+					Left: &ast.LiteralExpr{
 						Value: float64(5),
 					},
 					Operator: &token.Token{
@@ -61,7 +61,7 @@ func TestParse(t *testing.T) {
 						Line:   0,
 						Type:   token.MINUS,
 					},
-					Right: &ast.Literal{
+					Right: &ast.LiteralExpr{
 						Value: float64(3),
 					},
 				},
@@ -70,15 +70,15 @@ func TestParse(t *testing.T) {
 					Line:   0,
 					Type:   token.MINUS,
 				},
-				Right: &ast.Literal{
+				Right: &ast.LiteralExpr{
 					Value: float64(1),
 				},
 			},
 		},
 		{
 			input: "5 - 3 * 1",
-			expected: &ast.Binary{
-				Left: &ast.Literal{
+			expected: &ast.BinaryExpr{
+				Left: &ast.LiteralExpr{
 					Value: float64(5),
 				},
 				Operator: &token.Token{
@@ -86,8 +86,8 @@ func TestParse(t *testing.T) {
 					Line:   0,
 					Type:   token.MINUS,
 				},
-				Right: &ast.Binary{
-					Left: &ast.Literal{
+				Right: &ast.BinaryExpr{
+					Left: &ast.LiteralExpr{
 						Value: float64(3),
 					},
 					Operator: &token.Token{
@@ -95,7 +95,7 @@ func TestParse(t *testing.T) {
 						Line:   0,
 						Type:   token.STAR,
 					},
-					Right: &ast.Literal{
+					Right: &ast.LiteralExpr{
 						Value: float64(1),
 					},
 				},
@@ -103,10 +103,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			input: "(5 - 3) * 1",
-			expected: &ast.Binary{
-				Left: &ast.Grouping{
-					Expression: &ast.Binary{
-						Left: &ast.Literal{
+			expected: &ast.BinaryExpr{
+				Left: &ast.GroupingExpr{
+					Expression: &ast.BinaryExpr{
+						Left: &ast.LiteralExpr{
 							Value: float64(5),
 						},
 						Operator: &token.Token{
@@ -114,7 +114,7 @@ func TestParse(t *testing.T) {
 							Line:   0,
 							Type:   token.MINUS,
 						},
-						Right: &ast.Literal{
+						Right: &ast.LiteralExpr{
 							Value: float64(3),
 						},
 					},
@@ -124,29 +124,29 @@ func TestParse(t *testing.T) {
 					Line:   0,
 					Type:   token.STAR,
 				},
-				Right: &ast.Literal{
+				Right: &ast.LiteralExpr{
 					Value: float64(1),
 				},
 			},
 		},
 		{
 			input: "-69 < 420 == true",
-			expected: &ast.Binary{
-				Left: &ast.Binary{
-					Left: &ast.Unary{
+			expected: &ast.BinaryExpr{
+				Left: &ast.BinaryExpr{
+					Left: &ast.UnaryExpr{
 						Operator: &token.Token{
 							Lexeme: "-",
 							Line:   0,
 							Type:   token.MINUS,
 						},
-						Right: &ast.Literal{Value: float64(69)},
+						Right: &ast.LiteralExpr{Value: float64(69)},
 					},
 					Operator: &token.Token{
 						Lexeme: "<",
 						Line:   0,
 						Type:   token.LESS,
 					},
-					Right: &ast.Literal{
+					Right: &ast.LiteralExpr{
 						Value: float64(420),
 					},
 				},
@@ -155,7 +155,7 @@ func TestParse(t *testing.T) {
 					Line:   0,
 					Type:   token.EQUAL_EQUAL,
 				},
-				Right: &ast.Literal{Value: true},
+				Right: &ast.LiteralExpr{Value: true},
 			},
 		},
 		{


### PR DESCRIPTION
- Refactors and generalizes the `golox-ast` codegen entrypoint to be (somewhat) more readable in preparation for adding the `Stmt` types. 
- Renames `Visitor` to be `ExprVisitor` specifically, since `Stmt` has its own, disjoint `Visitor` interface.
- Suffixes all `Expr`-related AST nodes as such; not strictly necessary, but `Stmt` defines its own `ExpressionStmt` type and it was _a little much_. 