### PR TITLE
Add an io.Writer param to the interpreter

### DIFF
--- a/cmd/golox/main.go
+++ b/cmd/golox/main.go
@@ -36,13 +36,10 @@ func repl() {
 			continue
 		}
 
-		i := interpreter.New()
-		result, err := i.Interpret(expr)
-		if err != nil {
+		i := interpreter.New(os.Stdout)
+		if err := i.Interpret(expr); err != nil {
 			fmt.Println(err)
 			continue
 		}
-
-		fmt.Printf("%+v\n", result)
 	}
 }

--- a/golox/interpreter/interpreter.go
+++ b/golox/interpreter/interpreter.go
@@ -2,19 +2,31 @@ package interpreter
 
 import (
 	"errors"
+	"fmt"
+	"io"
 
 	"github.com/doeg/golox/golox/ast"
 	"github.com/doeg/golox/golox/token"
 )
 
-type Interpreter struct{}
-
-func New() *Interpreter {
-	return &Interpreter{}
+type Interpreter struct {
+	writer io.Writer
 }
 
-func (i *Interpreter) Interpret(expr ast.Expr) (any, error) {
-	return i.evaluate(expr)
+func New(writer io.Writer) *Interpreter {
+	return &Interpreter{
+		writer: writer,
+	}
+}
+
+func (i *Interpreter) Interpret(expr ast.Expr) error {
+	output, err := i.evaluate(expr)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.writer.Write([]byte(fmt.Sprintf("%+v\n", output)))
+	return err
 }
 
 func (i *Interpreter) VisitBinaryExpr(expr *ast.BinaryExpr) (any, error) {

--- a/golox/interpreter/interpreter_test.go
+++ b/golox/interpreter/interpreter_test.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -57,7 +58,8 @@ func TestIsTruthy(t *testing.T) {
 		t.Run(fmt.Sprintf("%+v", tt.input), func(t *testing.T) {
 			t.Parallel()
 
-			i := New()
+			var output bytes.Buffer
+			i := New(&output)
 			result := i.isTruthy(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -344,7 +346,8 @@ func TestVisitBinaryExpression(t *testing.T) {
 
 			expr := pExpr.(*ast.BinaryExpr)
 
-			i := New()
+			var output bytes.Buffer
+			i := New(&output)
 			result, err := i.VisitBinaryExpr(expr)
 			if tt.expectedError != nil {
 				require.Equal(t, tt.expectedError, err)
@@ -406,7 +409,8 @@ func TestVisitUnaryExpression(t *testing.T) {
 
 			expr := pExpr.(*ast.UnaryExpr)
 
-			i := New()
+			var output bytes.Buffer
+			i := New(&output)
 			result, err := i.VisitUnaryExpr(expr)
 			if tt.expectedError != nil {
 				require.Equal(t, tt.expectedError, err)


### PR DESCRIPTION
Soon, the interpreter will no longer return the value of evaluated expressions; it will only process statements, which don't really return values in an easily testable way.

This adds an `io.Writer` handle to the interpreter so that output (e.g., from `print someValue;`) can be captured by tests like this:

```go
var output bytes.Buffer
i := New(&output)
i.Interpret(stmts)

assert.Equal(t, tt.expected, output.String())
```

Existing behaviour is maintained by having the REPL entrypoint pass in `os.Stdout`:

```go
interpreter.New(os.Stdout)
```