### PR TITLE
Add expression + print statements to AST, parser, and interpreter

### DIFF
--- a/cmd/golox-ast/main.go
+++ b/cmd/golox-ast/main.go
@@ -51,6 +51,9 @@ func main() {
 			"Literal	:	Object value",
 			"Unary		:	Token operator, Expr right",
 		}),
+		defineAST("Stmt", []string{
+			"Expression :	Expr expression",
+		}),
 	}
 
 	t, err := template.New("golox-ast").Funcs(template.FuncMap{

--- a/cmd/golox-ast/main.go
+++ b/cmd/golox-ast/main.go
@@ -53,6 +53,7 @@ func main() {
 		}),
 		defineAST("Stmt", []string{
 			"Expression :	Expr expression",
+			"Print		: 	Expr expression",
 		}),
 	}
 

--- a/golox/ast/ast.go
+++ b/golox/ast/ast.go
@@ -50,3 +50,19 @@ type UnaryExpr struct {
 func (e *UnaryExpr) Accept(v ExprVisitor) (any, error) {
 	return v.VisitUnaryExpr(e)
 }
+
+type StmtVisitor interface {
+	VisitExpressionStmt(expr *ExpressionStmt) (any, error)
+}
+
+type Stmt interface {
+	Accept(StmtVisitor) (any, error)
+}
+
+type ExpressionStmt struct {
+	Expression Expr
+}
+
+func (e *ExpressionStmt) Accept(v StmtVisitor) (any, error) {
+	return v.VisitExpressionStmt(e)
+}

--- a/golox/ast/ast.go
+++ b/golox/ast/ast.go
@@ -53,6 +53,7 @@ func (e *UnaryExpr) Accept(v ExprVisitor) (any, error) {
 
 type StmtVisitor interface {
 	VisitExpressionStmt(expr *ExpressionStmt) (any, error)
+	VisitPrintStmt(expr *PrintStmt) (any, error)
 }
 
 type Stmt interface {
@@ -65,4 +66,12 @@ type ExpressionStmt struct {
 
 func (e *ExpressionStmt) Accept(v StmtVisitor) (any, error) {
 	return v.VisitExpressionStmt(e)
+}
+
+type PrintStmt struct {
+	Expression Expr
+}
+
+func (e *PrintStmt) Accept(v StmtVisitor) (any, error) {
+	return v.VisitPrintStmt(e)
 }

--- a/golox/interpreter/interpreter.go
+++ b/golox/interpreter/interpreter.go
@@ -2,6 +2,7 @@ package interpreter
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/doeg/golox/golox/ast"
@@ -118,6 +119,19 @@ func (i *Interpreter) VisitGroupingExpr(expr *ast.GroupingExpr) (any, error) {
 
 func (i *Interpreter) VisitLiteralExpr(expr *ast.LiteralExpr) (any, error) {
 	return expr.Value, nil
+}
+
+func (i *Interpreter) VisitPrintStmt(stmt *ast.PrintStmt) (any, error) {
+	expr, err := i.evaluate(stmt.Expression)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := i.writer.Write([]byte(fmt.Sprintf("%+v\n", expr))); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func (i *Interpreter) VisitUnaryExpr(expr *ast.UnaryExpr) (any, error) {

--- a/golox/interpreter/interpreter_test.go
+++ b/golox/interpreter/interpreter_test.go
@@ -341,7 +341,7 @@ func TestVisitBinaryExpression(t *testing.T) {
 			require.Empty(t, errs)
 
 			p := parser.New(tokens)
-			pExpr, err := p.Parse()
+			pExpr, err := p.ParseExpression()
 			require.Nil(t, err)
 
 			expr := pExpr.(*ast.BinaryExpr)
@@ -404,7 +404,7 @@ func TestVisitUnaryExpression(t *testing.T) {
 			require.Empty(t, errs)
 
 			p := parser.New(tokens)
-			pExpr, err := p.Parse()
+			pExpr, err := p.ParseExpression()
 			require.Nil(t, err)
 
 			expr := pExpr.(*ast.UnaryExpr)

--- a/golox/parser/parser.go
+++ b/golox/parser/parser.go
@@ -356,10 +356,35 @@ func (p *Parser) parsePrimary() (ast.Expr, error) {
 	return nil, errors.New(ErrExpectExpression)
 }
 
+// parsePrintStatement implements the following grammar rule:
+//
+//	printStmt -> "print" expression ";" ;
+func (p *Parser) parsePrintStatement() (ast.Stmt, error) {
+	expr, err := p.ParseExpression()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.consume(token.SEMICOLON, "expect ';' after expression"); err != nil {
+		return nil, err
+	}
+
+	return &ast.PrintStmt{
+		Expression: expr,
+	}, nil
+}
+
 // parseStatement implements the following grammar rule:
 //
-//	statement -> exprStmt ;
+//	statement -> exprStmt | printStmt ;
 func (p *Parser) parseStatement() (ast.Stmt, error) {
+	isPrint, err := p.match(token.PRINT)
+	if err != nil {
+		return nil, err
+	} else if isPrint {
+		return p.parsePrintStatement()
+	}
+
 	return p.parseExpressionStatement()
 }
 

--- a/golox/parser/parser.go
+++ b/golox/parser/parser.go
@@ -77,22 +77,22 @@ func (p *Parser) check(tokenType token.TokenType) (bool, error) {
 // consume checks to see if the next token is of the expected type.
 // If so, it consumes the token. If some other token is there, then we've
 // hit an error.
-func (p *Parser) consume(tokenType token.TokenType, message string) error {
+func (p *Parser) consume(tokenType token.TokenType, message string) (*token.Token, error) {
 	isMatch, err := p.check(tokenType)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !isMatch {
-		return errors.New(message)
+		return nil, errors.New(message)
 	}
 
-	_, err = p.advance()
+	tok, err := p.advance()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return tok, nil
 }
 
 // get returns a pointer to the Token at the given index.
@@ -302,8 +302,7 @@ func (p *Parser) parsePrimary() (ast.Expr, error) {
 			return nil, err
 		}
 
-		err = p.consume(token.RIGHT_PAREN, ErrExpectClosingParen)
-		if err != nil {
+		if _, err = p.consume(token.RIGHT_PAREN, ErrExpectClosingParen); err != nil {
 			return nil, err
 		}
 

--- a/golox/parser/parser.go
+++ b/golox/parser/parser.go
@@ -31,7 +31,7 @@ func New(tokens []*token.Token) *Parser {
 }
 
 func (p *Parser) Parse() (ast.Expr, error) {
-	expr, err := p.parseExpression()
+	expr, err := p.ParseExpression()
 	if err != nil {
 		// TODO check if instance of LoxParseError
 		// TODO the book returns nil here :thinking:
@@ -209,10 +209,10 @@ func (p *Parser) parseEquality() (ast.Expr, error) {
 	return expr, nil
 }
 
-// parseExpression implements the following grammar rule:
+// ParseExpression implements the following grammar rule:
 //
 //	expression -> equality ;
-func (p *Parser) parseExpression() (ast.Expr, error) {
+func (p *Parser) ParseExpression() (ast.Expr, error) {
 	return p.parseEquality()
 }
 
@@ -297,7 +297,7 @@ func (p *Parser) parsePrimary() (ast.Expr, error) {
 	if err != nil {
 		return nil, err
 	} else if isMatch {
-		expr, err := p.parseExpression()
+		expr, err := p.ParseExpression()
 		if err != nil {
 			return nil, err
 		}

--- a/golox/parser/parser_test.go
+++ b/golox/parser/parser_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParse(t *testing.T) {
+func TestParseExpression(t *testing.T) {
 	tests := []struct {
 		testName      string
 		input         string
@@ -185,7 +185,7 @@ func TestParse(t *testing.T) {
 			require.Empty(t, errors)
 
 			p := New(tokens)
-			expr, err := p.Parse()
+			expr, err := p.ParseExpression()
 
 			if tt.expectedError != nil {
 				assert.Nil(t, expr)


### PR DESCRIPTION
Pulling out more little pieces from my big gross branch. This is a fairly significant change, as it adjusts the parser and interpreter to work with statements (or declarations, I guess) rather than evaluating expressions + returning the result.

In addition to adding expression statements (which are the basis for _most_ kinds of statements), I also added support for the `print` statement so the REPL is still functional:

```
$ make repl
go build -o build/ ./...
./build/golox
> 1 + 3;
> print 1 + 3;
4
> print "hello";
hello
> print "oops"
expect ';' after expression
> print hmm
expect expression
```

Error handling still pretty clown-mode but whatevs. 🤡